### PR TITLE
fix: Update image syntax in README.md for Monaco Editor and Spec File Generation

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,7 +1,8 @@
 
-I am an expert AI assistant for the `gemini-cli-ui` project.
+# Gemini CLI Web UI Architecture
 
 **Core Architecture:**
+
 - **Frontend:** React, Vite, Tailwind CSS, with a component-based architecture. Key components include `App.jsx`, `Sidebar.jsx`, `MainContent.jsx`, `ChatInterface.jsx`, `FileTree.jsx`, and `GitPanel.jsx`.
 - **Backend:** Node.js with an Express server and a WebSocket layer for real-time communication.
 - **Database:** A local SQLite database (`geminicliui_auth.db`) is used for user authentication.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <img src="public/logo.svg" alt="Gemini CLI UI" width="64" height="64">
-  <h1>Gemini CLI UI</h1>
+  <h1>Gemini CLI Web UI</h1>
 </div>
 
 A desktop and mobile UI for [Gemini CLI](https://github.com/google-gemini/gemini-cli), Google's official CLI for AI-assisted coding. You can use it locally or remotely to view your active projects and sessions in Gemini CLI and make changes to them the same way you would do it in Gemini CLI. This gives you a proper interface that works everywhere.
@@ -35,13 +35,16 @@ A desktop and mobile UI for [Gemini CLI](https://github.com/google-gemini/gemini
 </table>
 </div align="center">
 
+<div align="center">
+<h3>Updates to Gemini CLI Web UI</h3>
 <img src="public/screenshots/Screenshot from 2025-07-23 11-23-30.png" alt="Gemini CLI Monaco Code Editor" width="800">
+<em>Monaco Code Editor for editing files in Gemini CLI UI</em>
 <br>
-<em>Monaco Code Editor for editing files in Gemini CLI UI</em>)
 
 <img src="public/screenshots/Screenshot from 2025-07-23 11-22-18.png" alt="Gemini CLI Monaco Code Editor" width="800">
+<em>Spec File Generation</em>
 <br>
-<em>Spec File Generation</em>)
+</div align="center">
 
 ## Features
 
@@ -163,6 +166,26 @@ The UI automatically discovers Gemini CLI projects from `~/.gemini/projects/` an
 - **Mobile Navigation** - Bottom tab bar for easy thumb navigation
 - **Adaptive Layout** - Collapsible sidebar and smart content prioritization
 - **Add to Home Screen** - Add a shortcut to your home screen and the app will behave like a PWA
+
+### Monaco Editor
+
+- **Monaco Editor** - Advanced code editor with syntax highlighting and live editing
+- **Code Completion** - Autocomplete features for code snippets and functions
+- **Syntax Highlighting** - Highlighting of different programming languages
+- **Live Editing** - Edit code directly in the editor
+- **Code Folding** - Collapse and expand code blocks for better readability
+- **Chat Modal** - Chat mode that can interact with the Monaco Editor
+
+### Spec File Generation
+
+- **Spec File Generation** - Generate design, requirements, and tasks files
+- **Design File Generation** - Generate design files for UI
+- **Requirements File Generation** - Generate requirements files for testing
+- **Tasks File Generation** - Generate tasks files for automation
+- **User Input** - User input is used to generate the spec files
+- **Retry and Save** - Retry and save the generated spec files
+- **Save Spec Files** - Save the generated spec files, in the project spec folder
+- **Use Spec Files** - Use the generated spec files in Gemini CLI for further development, features, and more.
 
 ## Architecture
 

--- a/index.html
+++ b/index.html
@@ -4,28 +4,28 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-    <title>Gemini CLI UI</title>
-    
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>Gemini CLI Web UI</title>
+
     <!-- PWA Manifest -->
     <link rel="manifest" href="/manifest.json" />
-    
+
     <!-- iOS Safari PWA Meta Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Gemini UI" />
-    
+
     <!-- iOS Safari Icons -->
     <link rel="apple-touch-icon" sizes="152x152" href="/icons/icon-152x152.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/icons/icon-192x192.png" />
-    
+
     <!-- Theme Color -->
     <meta name="theme-color" content="#ffffff" />
     <meta name="msapplication-TileColor" content="#ffffff" />
-    
+
     <!-- Prevent zoom on iOS -->
     <meta name="format-detection" content="telephone=no" />
-    
+
     <!-- Critical CSS to prevent layout shift -->
     <style>
       /* Prevent layout shift during loading */
@@ -35,26 +35,26 @@
         overflow-x: hidden;
         min-height: 100vh;
       }
-      
+
       #root {
         min-height: 100vh;
         display: flex;
         flex-direction: column;
       }
-      
+
       /* Prevent FOUC (Flash of Unstyled Content) */
       .no-fouc {
         visibility: hidden;
         opacity: 0;
       }
-      
+
       /* Loading skeleton styles */
       .skeleton {
         background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
         background-size: 200% 100%;
         animation: loading 1.5s infinite;
       }
-      
+
       @keyframes loading {
         0% {
           background-position: 200% 0;
@@ -68,7 +68,7 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
-    
+
     <!-- Service Worker Registration -->
     <script>
       if ('serviceWorker' in navigator) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gemini-cli-ui",
-  "version": "1.5.0",
+  "name": "gemini-cli-web",
+  "version": "1.0.0",
   "description": "A stylish web-based UI for Gemini CLI",
   "type": "module",
   "main": "server/index.js",
@@ -19,7 +19,7 @@
     "ui",
     "assistant"
   ],
-  "author": "Gemini CLI UI Contributors",
+  "author": "ssdeanx",
   "license": "MIT",
   "dependencies": {
     "@codemirror/lang-css": "^6.3.1",


### PR DESCRIPTION
Improvements

## Summary by Sourcery

Revise project branding to "Gemini CLI Web UI", enhance README with detailed sections for Monaco Editor and Spec File Generation, and update project metadata and HTML template accordingly.

Enhancements:
- Adjust index.html meta viewport attributes and update document title to reflect the Web UI branding

Build:
- Update package.json name to "gemini-cli-web", reset version to 1.0.0, and change author to ssdeanx

Documentation:
- Rename instances of "Gemini CLI UI" to "Gemini CLI Web UI" across README, index.html, package.json, and GEMINI.md
- Add dedicated screenshot captions and grouping div for Monaco Editor and Spec File Generation in README
- Expand README Features with detailed bullet points for Monaco Editor and Spec File Generation functionalities
- Refine GEMINI.md header to document the Web UI architecture

Chores:
- Clean up whitespace and formatting in HTML and Markdown files